### PR TITLE
[FIX] Add the organization_id.github_login to the github url

### DIFF
--- a/github_connector/models/github_repository_branch.py
+++ b/github_connector/models/github_repository_branch.py
@@ -295,5 +295,6 @@ class GithubRepository(models.Model):
         for branch in self:
             branch.github_url =\
                 'https://github.com/' +\
+                branch.organization_id.github_login + '/' +\
                 branch.repository_id.complete_name +\
                 '/tree/' + branch.name


### PR DESCRIPTION
Making the github url the form: https://github.com/OCA/account-analytic/tree/9.0
and not the https://github.com/account-analytic/tree/9.0 before this commit